### PR TITLE
Fix: Changed  edit endpoint url

### DIFF
--- a/domains/comment/routers/comment.router.js
+++ b/domains/comment/routers/comment.router.js
@@ -8,7 +8,7 @@ const auth = require('../../../middlewares/auth');
 const router = express.Router();
 
 router.patch(
-  '/:id',
+  '/:id/edit',
   auth,
   validator.postCommentValidator,
   formatter.postCommentFormatter,


### PR DESCRIPTION
- Changed from '/comments/:id' to '/comments/:id/edit' for consistency across API