### PR TITLE
Fix: Logic error in get questions and get comments

### DIFF
--- a/domains/comment/services/get-comments.js
+++ b/domains/comment/services/get-comments.js
@@ -25,7 +25,7 @@ const getComments = async ({ answerId = '', start = 0, limit = 20 }) => {
 
     const pageInfo = pageInfoHelper.createPageInfo(count, start, limit);
 
-    return { ...pageInfo, answers: rows };
+    return { ...pageInfo, comments: rows };
   } catch (e) {
     return serviceErrorHandler(e);
   }

--- a/domains/question/services/get-question.js
+++ b/domains/question/services/get-question.js
@@ -20,7 +20,7 @@ const getQuestion = async (id) => {
 
     const question = await query.execFindByPk(id);
 
-    if (question && !question.id) throw new RequestError(404, 'No question found');
+    if (!question || !question.id) throw new RequestError(404, 'No question found');
 
     return question;
   } catch (e) {


### PR DESCRIPTION
- Get Questions sent null when no questions was found instead of throwing  a 404 error due to bad if logic
- Get Comments response object had property **_answers_** instead of **_comments_**