### PR TITLE
Fix: Removed Auth Middleware in Get Queries

### DIFF
--- a/domains/answer/routers/answer.router.js
+++ b/domains/answer/routers/answer.router.js
@@ -91,7 +91,6 @@ router.post(
 
 router.get(
   '/:id/comments',
-  auth,
   validator.getCommentsValidator,
   formatter.getCommentsFormatter,
   (req, res) => {

--- a/domains/question/routers/question.router.js
+++ b/domains/question/routers/question.router.js
@@ -19,7 +19,6 @@ router.post(
 
 router.get(
   '/',
-  auth,
   validator.getQuestionsValidator,
   formatter.getQuestionsFormatter,
   (req, res) => {
@@ -39,7 +38,6 @@ router.get(
 
 router.get(
   '/:id',
-  auth,
   validator.idParamValidator,
   (req, res) => {
     responseHandler(req.params.id, res, controller.getQuestion);
@@ -88,7 +86,6 @@ router.post(
 
 router.get(
   '/:id/answers',
-  auth,
   validator.getQuestionAnswersValidator,
   formatter.getQuestionAnswersFormatter,
   (req, res) => {


### PR DESCRIPTION
This allows unauthenticated users to view questions, answers and comments without editing or deleting rights.